### PR TITLE
fix: src/entry.js does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "cross-env NODE_ENV=development babel-watch --presets es2015 src/server.js",
     "babel": "babel --presets es2015 src -d dist --ignore components*",
     "build": "webpack --config src/webpack.prod.js && npm run babel",
-    "prod": "node src/entry.js",
+    "prod": "node dist/server.js",
     "lint": "eslint ."
   },
   "engines": {


### PR DESCRIPTION
Changed `src/entry.js` to `dist/server.js` so that the `npm run prod` command can work properly.